### PR TITLE
Replaced Homogenous Button with Slider

### DIFF
--- a/gruepr.pro
+++ b/gruepr.pro
@@ -96,6 +96,7 @@ SOURCES += \
         LMS/LMS.cpp \
         LMS/canvashandler.cpp \
         LMS/googlehandler.cpp \
+        widgets/attributeDiversitySlider.cpp \
         widgets/attributeWidget.cpp \
         widgets/boxwhiskerplot.cpp \
         widgets/comboBoxWithElidedContents.cpp \
@@ -142,6 +143,7 @@ HEADERS += \
         LMS/LMS.h \
         LMS/canvashandler.h \
         LMS/googlehandler.h \
+        widgets/attributeDiversitySlider.h \
         widgets/attributeWidget.h \
         widgets/boxwhiskerplot.h \
         widgets/comboBoxWithElidedContents.h \

--- a/gruepr.ui
+++ b/gruepr.ui
@@ -57,9 +57,9 @@ QGroupBox::title { subcontrol-origin: margin; left: 7px; padding: 0px 5px 0px 5p
          <property name="geometry">
           <rect>
            <x>0</x>
-           <y>-153</y>
-           <width>481</width>
-           <height>679</height>
+           <y>0</y>
+           <width>498</width>
+           <height>549</height>
           </rect>
          </property>
          <property name="sizePolicy">

--- a/teamingOptions.h
+++ b/teamingOptions.h
@@ -11,6 +11,12 @@
 class TeamingOptions
 {
 public:
+    enum class AttributeDiversity {
+        HOMOGENOUS,
+        HETEROGENOUS,
+        IGNORED
+    };
+
     TeamingOptions();
     explicit TeamingOptions(const QJsonObject &jsonTeamingOptions);
     void reset();
@@ -27,7 +33,7 @@ public:
     int minTimeBlocksOverlap = 4;                       // a team is penalized if there are fewer than this many time blocks that overlap
     float meetingBlockSize = 1;                         // the minimum length of schedule overlap to count as a meeting time (in units of hours)
     int realMeetingBlockSize = 1;                       // the minimum length of schedule overlap (in units of # of blocks in schedule)
-    bool desireHomogeneous[MAX_ATTRIBUTES]; 			// if true/false, tries to make all students on a team have similar/different levels of each attribute
+    AttributeDiversity attributeDiversity[MAX_ATTRIBUTES]; 			// if true/false, tries to make all students on a team have similar/different levels of each attribute
     float attributeWeights[MAX_ATTRIBUTES];             // weights for each attribute as displayed to the user (i.e., non-normalized values)
     float realAttributeWeights[MAX_ATTRIBUTES];         // scoring weight of each attribute, normalized to total weight
     bool haveAnyRequiredAttributes[MAX_ATTRIBUTES];
@@ -49,6 +55,8 @@ public:
     int numTeamsDesired = 1;
     QString sectionName;
     enum class SectionType {noSections, allTogether, allSeparately, oneSection} sectionType = SectionType::noSections;
+    static QString attributeDiversityToString(TeamingOptions::AttributeDiversity value);
+    static AttributeDiversity stringToAttributeDiversity(const QString& str);
     int teamsetNumber = 1;                              // which teamset are we working on now?
     inline static const int MAXWEIGHT = 10;             // the maximum value the user can assign for an attribute or schedule weight
     inline static const QString WEIGHTTOOLTIP = "<html>" + QObject::tr("The relative importance of this question in forming the teams. The range is from 0 to ") +

--- a/widgets/attributeDiversitySlider.cpp
+++ b/widgets/attributeDiversitySlider.cpp
@@ -1,0 +1,37 @@
+#include "attributeDiversitySlider.h"
+#include <QSlider>
+#include <teamingOptions.cpp>
+#include "gruepr_globals.h"
+AttributeDiversitySlider::AttributeDiversitySlider(QWidget *parent): QSlider(Qt::Horizontal, parent) {
+    setRange(0, 2);  // Set min-max values
+    setTickPosition(QSlider::TicksBelow);
+    setTickInterval(1);
+    setValue(1);
+    setStyleSheet("QSlider::handle:horizontal { background: " OPENWATERHEX "; width: 10px; height: 10px; border-radius: 5px; }");
+}
+
+TeamingOptions::AttributeDiversity AttributeDiversitySlider::getAttributeDiversityFromSliderIndex(int sliderIndex){
+    if (sliderIndex == 0){
+        return TeamingOptions::AttributeDiversity::HETEROGENOUS;
+    } else if (sliderIndex == 1){
+        return TeamingOptions::AttributeDiversity::IGNORED;
+    } else if (sliderIndex == 2){
+        return TeamingOptions::AttributeDiversity::HOMOGENOUS;
+    } else {
+        return TeamingOptions::AttributeDiversity::IGNORED;
+    }
+}
+
+int AttributeDiversitySlider::getSliderIndexFromAttributeDiversity(TeamingOptions::AttributeDiversity attributeDiversity){
+    if (attributeDiversity == TeamingOptions::AttributeDiversity::HETEROGENOUS){
+        return 0;
+    } else if (attributeDiversity == TeamingOptions::AttributeDiversity::IGNORED){
+        return 1;
+    } else if (attributeDiversity == TeamingOptions::AttributeDiversity::HOMOGENOUS){
+        return 2;
+    } else{
+        return 1;
+    }
+}
+
+

--- a/widgets/attributeDiversitySlider.h
+++ b/widgets/attributeDiversitySlider.h
@@ -1,0 +1,15 @@
+#ifndef ATTRIBUTEDIVERSITYSLIDER_H
+#define ATTRIBUTEDIVERSITYSLIDER_H
+#include <QSlider>
+#include <teamingOptions.h>
+
+class AttributeDiversitySlider : public QSlider
+{
+    Q_OBJECT
+public:
+    AttributeDiversitySlider(QWidget *parent = nullptr);
+    static TeamingOptions::AttributeDiversity getAttributeDiversityFromSliderIndex(int sliderIndex);
+    static int getSliderIndexFromAttributeDiversity(TeamingOptions::AttributeDiversity attributeDiversity);
+
+};
+#endif // ATTRIBUTEDIVERSITYSLIDER_H

--- a/widgets/attributeWidget.cpp
+++ b/widgets/attributeWidget.cpp
@@ -1,4 +1,5 @@
 #include "attributeWidget.h"
+#include "attributeDiversitySlider.cpp"
 #include <QApplication>
 #include <QFrame>
 #include <QGridLayout>
@@ -46,12 +47,20 @@ AttributeWidget::AttributeWidget(QWidget *parent) : QWidget(parent)
     weight->setValue(1);
     theGrid->addWidget(weight, row, column++);
     theGrid->setColumnStretch(column++, 1);
-    auto *homogenLabel = new QLabel(tr("Homogeneous Values"), this);
-    homogenLabel->setToolTip(HOMOGENTOOLTIP);
-    theGrid->addWidget(homogenLabel, row, column++);
-    homogeneous = new SwitchButton(this, true);
-    homogeneous->setToolTip(HOMOGENTOOLTIP);
-    theGrid->addWidget(homogeneous, row++, column);
+
+    auto *sliderLabel = new QLabel(tr("Attribute Diversity"), this);
+    sliderLabel->setToolTip(HOMOGENTOOLTIP);
+    theGrid->addWidget(sliderLabel, row, column++);
+    attribute_diversity_slider = new AttributeDiversitySlider(this);
+    attribute_diversity_slider->setToolTip(HOMOGENTOOLTIP);
+    QLabel *sliderLabel1 = new QLabel("Diverse", this);
+    QLabel *sliderLabel2 = new QLabel("Ignore", this);
+    QLabel *sliderLabel3 = new QLabel("Similar", this);
+    theGrid->addWidget(attribute_diversity_slider, row++, column, 1, 3);
+    // Align labels under the slider evenly
+    theGrid->addWidget(sliderLabel1, row, column++, Qt::AlignLeft);
+    theGrid->addWidget(sliderLabel2, row, column++, Qt::AlignLeft);
+    theGrid->addWidget(sliderLabel3, row++, column, Qt::AlignLeft);
 
     requiredIncompatsButton = new QPushButton(tr("Set Rules"), this);
     requiredIncompatsButton->setToolTip(REQUIREDINCOMPATTOOLTIP);
@@ -65,7 +74,7 @@ void AttributeWidget::setValues(int attribute, const DataOptions *const dataOpti
         questionLabel->setText(tr("N/A"));
         responsesLabel->setText(tr("N/A"));
         weight->setEnabled(false);
-        homogeneous->setEnabled(false);
+        attribute_diversity_slider->setEnabled(false);
         requiredIncompatsButton->setEnabled(false);
         return;
     }
@@ -76,21 +85,22 @@ void AttributeWidget::setValues(int attribute, const DataOptions *const dataOpti
         teamingOptions->attributeWeights[attribute] = 0;
         weight->setEnabled(false);
         weight->setToolTip(ONLYONETOOLTIP);
-        homogeneous->setEnabled(false);
-        homogeneous->setToolTip(ONLYONETOOLTIP);
+        attribute_diversity_slider->setEnabled(false);
+        attribute_diversity_slider->setToolTip(ONLYONETOOLTIP);
         requiredIncompatsButton->setEnabled(false);
         requiredIncompatsButton->setToolTip(ONLYONETOOLTIP);
     }
     else {
         weight->setEnabled(true);
         weight->setToolTip(TeamingOptions::WEIGHTTOOLTIP);
-        homogeneous->setEnabled(true);
-        homogeneous->setToolTip(HOMOGENTOOLTIP);
+        attribute_diversity_slider->setEnabled(true);
+        attribute_diversity_slider->setToolTip(HOMOGENTOOLTIP);
         requiredIncompatsButton->setEnabled(true);
         requiredIncompatsButton->setToolTip(REQUIREDINCOMPATTOOLTIP);
     }
     weight->setValue(double(teamingOptions->attributeWeights[attribute]));
-    homogeneous->setValue(teamingOptions->desireHomogeneous[attribute]);
+    //Convert AttributeDiversity to Slider Index then set slider value
+    attribute_diversity_slider->setValue(AttributeDiversitySlider::getSliderIndexFromAttributeDiversity(teamingOptions->attributeDiversity[attribute]));
 }
 
 void AttributeWidget::updateQuestionAndResponses(int attribute, const DataOptions *const dataOptions, const std::map<QString, int> &responseCounts)

--- a/widgets/attributeWidget.h
+++ b/widgets/attributeWidget.h
@@ -3,10 +3,10 @@
 
 #include "dataOptions.h"
 #include "teamingOptions.h"
-#include "widgets/switchButton.h"
 #include <QDoubleSpinBox>
 #include <QLabel>
 #include <QPushButton>
+#include <QSlider>
 
 class AttributeWidget : public QWidget
 {
@@ -14,14 +14,14 @@ Q_OBJECT
 
 public:
     explicit AttributeWidget(QWidget *parent = nullptr);
-
+    //This function sets the values for a particular attribute (multiple choice) question
     void setValues(int attribute, const DataOptions *const dataOptions, TeamingOptions *teamingOptions);
     void updateQuestionAndResponses(int attribute, const DataOptions *const dataOptions, const std::map<QString, int> &responseCounts={});
 
     QLabel *questionLabel = nullptr;
     QLabel *responsesLabel = nullptr;
     QDoubleSpinBox *weight = nullptr;
-    SwitchButton *homogeneous = nullptr;
+    QSlider *attribute_diversity_slider = nullptr;
     QPushButton *requiredIncompatsButton = nullptr;
 
 private:

--- a/widgets/teamsTabItem.cpp
+++ b/widgets/teamsTabItem.cpp
@@ -1311,8 +1311,15 @@ QStringList TeamsTabItem::createStdFileContents()
     }
     for(int attrib = 0; attrib < teams.dataOptions.numAttributes; attrib++) {
         instructorsFileContents += "\n" + tr("Multiple choice Q") + QString::number(attrib+1) + ": "
-                + tr("weight") + " = " + QString::number(double(teamingOptions->attributeWeights[attrib])) +
-                + ", " + (teamingOptions->desireHomogeneous[attrib]? tr("homogeneous") : tr("heterogeneous"));
+                                   + tr("weight") + " = " + QString::number(double(teamingOptions->attributeWeights[attrib]));
+        // Check the attribute diversity type explicitly
+        if (teamingOptions->attributeDiversity[attrib] == TeamingOptions::AttributeDiversity::HOMOGENOUS) {
+            instructorsFileContents += ", " + tr("homogeneous");
+        } else if (teamingOptions->attributeDiversity[attrib] == TeamingOptions::AttributeDiversity::HETEROGENOUS) {
+            instructorsFileContents += ", " + tr("heterogeneous");
+        } else {
+            instructorsFileContents += ", " + tr("ignored");
+        }
     }
     instructorsFileContents += "\n\n\n";
     for(int attrib = 0; attrib < teams.dataOptions.numAttributes; attrib++) {
@@ -1510,8 +1517,14 @@ QString TeamsTabItem::createCustomFileContents(WhichFilesDialog::CustomFileOptio
         }
         for(int attrib = 0; attrib < teams.dataOptions.numAttributes; attrib++) {
             customFileContents += "\n" + tr("Multiple choice Q") + QString::number(attrib+1) + ": "
-                                       + tr("weight") + " = " + QString::number(double(teamingOptions->attributeWeights[attrib])) +
-                                       + ", " + (teamingOptions->desireHomogeneous[attrib]? tr("homogeneous") : tr("heterogeneous"));
+                                  + tr("weight") + " = " + QString::number(double(teamingOptions->attributeWeights[attrib]));
+            if (teamingOptions->attributeDiversity[attrib] == TeamingOptions::AttributeDiversity::HOMOGENOUS) {
+                customFileContents += ", " + tr("homogeneous");
+            } else if (teamingOptions->attributeDiversity[attrib] == TeamingOptions::AttributeDiversity::HETEROGENOUS) {
+                customFileContents += ", " + tr("heterogeneous");
+            } else {
+                customFileContents += ", " + tr("ignored");
+            }
         }
         customFileContents += "\n\n\n";
         for(int attrib = 0; attrib < teams.dataOptions.numAttributes; attrib++) {

--- a/widgets/teamsTabItem.cpp
+++ b/widgets/teamsTabItem.cpp
@@ -542,7 +542,7 @@ void TeamsTabItem::swapStudents(const QList<int> &arguments) // QList<int> argum
             }
             const int numStudentsOnTeam = studentATeam.size;
             QList<TeamTreeWidgetItem*> childItems;
-            childItems.reserve(numStudentsOnTeam);
+            childItems.resize(numStudentsOnTeam);
             for(int studentNum = 0; studentNum < numStudentsOnTeam; studentNum++) {
                 //Find each teammate based on the ID and make them a leaf on the old team
                 const StudentRecord* teammate = findStudentFromID(studentATeam.studentIDs.at(studentNum));
@@ -606,28 +606,29 @@ void TeamsTabItem::swapStudents(const QList<int> &arguments) // QList<int> argum
             }
             const int numStudentsOnTeamA = studentATeam.size;
             const int numStudentsOnTeamB = studentBTeam.size;
-            QList<TeamTreeWidgetItem*> childItems;
-            childItems.reserve(std::max(numStudentsOnTeamA, numStudentsOnTeamB));
+            QList<TeamTreeWidgetItem*> childItemsTeamA;
+            childItemsTeamA.resize(numStudentsOnTeamA);
             for(int studentNum = 0; studentNum < numStudentsOnTeamA; studentNum++) {
                 //Find each teammate based on the ID and make them a leaf on the team
                 const StudentRecord* teammate = findStudentFromID(studentATeam.studentIDs.at(studentNum));
                 if(teammate == nullptr) {
                     continue;
                 }
-                childItems[studentNum] = new TeamTreeWidgetItem(TeamTreeWidgetItem::TreeItemType::student);
-                teamDataTree->refreshStudent(childItems[studentNum], *teammate, &teams.dataOptions, teamingOptions);
-                studentATeamItem->addChild(childItems[studentNum]);
+                childItemsTeamA[studentNum] = new TeamTreeWidgetItem(TeamTreeWidgetItem::TreeItemType::student);
+                teamDataTree->refreshStudent(childItemsTeamA[studentNum], *teammate, &teams.dataOptions, teamingOptions);
+                studentATeamItem->addChild(childItemsTeamA[studentNum]);
             }
-            childItems.clear();
+            QList<TeamTreeWidgetItem*> childItemsTeamB;
+            childItemsTeamB.resize(numStudentsOnTeamB);
             for(int studentNum = 0; studentNum < numStudentsOnTeamB; studentNum++) {
                 //Find each teammate based on the ID and make them a leaf on the team
                 const StudentRecord* teammate = findStudentFromID(studentBTeam.studentIDs.at(studentNum));
                 if(teammate == nullptr) {
                     continue;
                 }
-                childItems[studentNum] = new TeamTreeWidgetItem(TeamTreeWidgetItem::TreeItemType::student);
-                teamDataTree->refreshStudent(childItems[studentNum], *teammate, &teams.dataOptions, teamingOptions);
-                studentBTeamItem->addChild(childItems[studentNum]);
+                childItemsTeamB[studentNum] = new TeamTreeWidgetItem(TeamTreeWidgetItem::TreeItemType::student);
+                teamDataTree->refreshStudent(childItemsTeamB[studentNum], *teammate, &teams.dataOptions, teamingOptions);
+                studentBTeamItem->addChild(childItemsTeamB[studentNum]);
             }
         }
     }
@@ -735,28 +736,29 @@ void TeamsTabItem::moveAStudent(const QList<int> &arguments) // QList<int> argum
         //clear and refresh student items on both teams in table
         const int numStudentsOnOldTeam = oldTeam.size;
         const int numStudentsOnNewTeam = newTeam.size;
-        QList<TeamTreeWidgetItem*> childItems;
-        childItems.reserve(std::max(numStudentsOnOldTeam, numStudentsOnNewTeam));
+        QList<TeamTreeWidgetItem*> childItemsOldTeam;
+        childItemsOldTeam.resize(std::max(numStudentsOnOldTeam, numStudentsOnNewTeam));
         for(int studentNum = 0; studentNum < numStudentsOnOldTeam; studentNum++) {
             //Find each teammate based on the ID and make them a leaf on the old team
             const StudentRecord* teammate = findStudentFromID(oldTeam.studentIDs.at(studentNum));
             if(teammate == nullptr) {
                 continue;
             }
-            childItems[studentNum] = new TeamTreeWidgetItem(TeamTreeWidgetItem::TreeItemType::student);
-            teamDataTree->refreshStudent(childItems[studentNum], *teammate, &teams.dataOptions, teamingOptions);
-            oldTeamItem->addChild(childItems[studentNum]);
+            childItemsOldTeam[studentNum] = new TeamTreeWidgetItem(TeamTreeWidgetItem::TreeItemType::student);
+            teamDataTree->refreshStudent(childItemsOldTeam[studentNum], *teammate, &teams.dataOptions, teamingOptions);
+            oldTeamItem->addChild(childItemsOldTeam[studentNum]);
         }
-        childItems.clear();
+        QList<TeamTreeWidgetItem*> childItemsNewTeam;
+        childItemsNewTeam.resize(std::max(numStudentsOnOldTeam, numStudentsOnNewTeam));
         for(int studentNum = 0; studentNum < numStudentsOnNewTeam; studentNum++) {
             //Find each teammate based on the ID and make them a leaf on the new team
             const StudentRecord* teammate = findStudentFromID(newTeam.studentIDs.at(studentNum));
             if(teammate == nullptr) {
                 continue;
             }
-            childItems[studentNum] = new TeamTreeWidgetItem(TeamTreeWidgetItem::TreeItemType::student);
-            teamDataTree->refreshStudent(childItems[studentNum], *teammate, &teams.dataOptions, teamingOptions);
-            newTeamItem->addChild(childItems[studentNum]);
+            childItemsNewTeam[studentNum] = new TeamTreeWidgetItem(TeamTreeWidgetItem::TreeItemType::student);
+            teamDataTree->refreshStudent(childItemsNewTeam[studentNum], *teammate, &teams.dataOptions, teamingOptions);
+            newTeamItem->addChild(childItemsNewTeam[studentNum]);
         }
     }
 


### PR DESCRIPTION
## New Changes

- Added new AttributeDiversitySlider Widget, to allow users to select the grouping attribute diversity for multiple choice questions in a less confusing way, giving options for: Similar (Homogenous), Diverse (Heterogenous) and Ignore (criteria is ignored).
- When the criteria is ignored, the relative weight is set to 0 so it is not taken into account during the fitness function calculation.
- Homogenous, Heterogenous and Ignore are part of the Enum class: AttributeDiversity in TeamingOptions.
- Added static methods to convert AttributeDiversity Enum into String and back, as well as into the QSlider Index values. 

## Bug Fixes
- Fixed bug where upon swapping students in different teams or adding students to other teams, the software crashes due to index out of range exception.


## Image of Changes

Below is an image of the slider, utilizing some mock student data.

<img width="454" alt="Capture" src="https://github.com/user-attachments/assets/f142c544-03ce-42e5-909f-01ff9e303f2f" />
